### PR TITLE
EX-236: hotfix for date filters

### DIFF
--- a/backend/exence/src/main/java/com/exence/finance/modules/transaction/dto/request/TransactionFilter.java
+++ b/backend/exence/src/main/java/com/exence/finance/modules/transaction/dto/request/TransactionFilter.java
@@ -13,7 +13,6 @@ import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
-import org.springframework.format.annotation.DateTimeFormat;
 
 import java.io.Serializable;
 import java.math.BigDecimal;
@@ -39,10 +38,8 @@ public class TransactionFilter implements Serializable {
             message = "Keyword must be at most " + TRANSACTION_TITLE_MAX_LENGTH + " characters")
     private String keyword;
 
-    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
     private Instant dateFrom;
 
-    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
     private Instant dateTo;
 
     private Long categoryId;

--- a/backend/exence/src/main/java/com/exence/finance/modules/transaction/repository/TransactionRepository.java
+++ b/backend/exence/src/main/java/com/exence/finance/modules/transaction/repository/TransactionRepository.java
@@ -25,8 +25,8 @@ public interface TransactionRepository extends JpaRepository<Transaction, Long> 
             "LOWER(t.note) LIKE %:#{#filter.keyword?.toLowerCase()}%) " +
             "AND (:#{#filter.categoryId} IS NULL OR t.category.id = :#{#filter.categoryId}) " +
             "AND (:#{#filter.type} IS NULL OR t.type = :#{#filter.type}) " +
-            "AND (:#{#filter.dateFrom} IS NULL OR t.date >= :#{#filter.dateFrom}) " +
-            "AND (:#{#filter.dateTo} IS NULL OR t.date <= :#{#filter.dateTo}) " +
+            "AND (COALESCE(:#{#filter.dateFrom}, t.date) IS NULL OR t.date >= COALESCE(:#{#filter.dateFrom}, t.date)) " +
+            "AND (COALESCE(:#{#filter.dateTo}, t.date) IS NULL OR t.date <= COALESCE(:#{#filter.dateTo}, t.date)) " +
             "AND (:#{#filter.amountFrom} IS NULL OR t.amount >= :#{#filter.amountFrom}) " +
             "AND (:#{#filter.amountTo} IS NULL OR t.amount <= :#{#filter.amountTo}) " +
             "AND (:#{#filter.recurring} IS NULL OR t.recurring = :#{#filter.recurring}) " +


### PR DESCRIPTION
 a jpql nem tudja kitalalni hogy milyen tipusu, ezert a postgresnek bytea formatumba adja tovabb, o meg nem tudja hogy ez egy datum, nem ismeri fel
 
 tobb megoldas is van:
1: nem TransactionFilter objectet adunk at a jpqlnek, hanem kulon Instant dateFrom parameter fixeli

2: a t.date-et ismeri, ezert a COALESCE kis hack miatt felismeri a postgres hogy mive kell castolni (sima CAST AS TIMESTAMP nem mukodik)
ideiglenes megoldas

3: ez lesz a vegso megoldas: specification API-t vezetek majd be nehany keresre, sokkal szebb lesz, biztonsagosabbak, es hatekonyabbak lesznek a queryk (nem kell bele a sok IS NULL = gyorsabb query
erre mar vettem fel ticketet, holnap megcsinalom