### PR TITLE
EX-63: Migrate to modern argon2 password hashing

### DIFF
--- a/backend/exence/build.gradle.kts
+++ b/backend/exence/build.gradle.kts
@@ -33,6 +33,9 @@ dependencies {
     implementation(libs.spring.security.web)
     implementation(libs.spring.security.jwt)
 
+    // Password Hashing (Argon2)
+    implementation(libs.bouncycastle)
+
     // JWT
     implementation(libs.jjwt.api)
     runtimeOnly(libs.jjwt.impl)

--- a/backend/exence/gradle/libs.versions.toml
+++ b/backend/exence/gradle/libs.versions.toml
@@ -11,6 +11,7 @@ lombok-mapstruct-binding = "0.2.0"
 emoji-java = "5.1.1"
 postgresql = "42.7.4"
 mockito = "5.5.0"
+bouncycastle = "1.70"
 
 [libraries]
 spring-boot-starter-data-jpa = { module = "org.springframework.boot:spring-boot-starter-data-jpa" }
@@ -35,6 +36,7 @@ lombok-mapstruct-binding = { module = "org.projectlombok:lombok-mapstruct-bindin
 emoji-java = { module = "com.vdurmont:emoji-java", version.ref = "emoji-java" }
 postgresql = { module = "org.postgresql:postgresql", version.ref = "postgresql" }
 mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockito" }
+bouncycastle = { module = "org.bouncycastle:bcprov-jdk15on", version.ref = "bouncycastle" }
 
 [plugins]
 spring-boot = { id = "org.springframework.boot", version.ref = "spring-boot" }

--- a/backend/exence/src/main/java/com/exence/finance/config/ApplicationConfig.java
+++ b/backend/exence/src/main/java/com/exence/finance/config/ApplicationConfig.java
@@ -10,7 +10,7 @@ import org.springframework.security.authentication.AuthenticationProvider;
 import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.core.userdetails.UserDetailsService;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.argon2.Argon2PasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 @Configuration
@@ -39,6 +39,7 @@ public class ApplicationConfig {
 
     @Bean
     public PasswordEncoder passwordEncoder() {
-        return new BCryptPasswordEncoder();
+        // argon2 parameters: saltLength=16, hashLength=32, parallelism=1, memory=65536 (64MB), iterations=3
+        return Argon2PasswordEncoder.defaultsForSpringSecurity_v5_8();
     }
 }


### PR DESCRIPTION
### BCrypt:

**CPU-igényes**: A lassítását azzal éri el, hogy sok processzorciklust igényel.
**A probléma**: A modern hackerek GPU-kat (videókártyákat) és speciális hardvereket (ASIC/FPGA) használnak jelszótörésre. Mivel a BCrypt kevés memóriát használ, a GPU-k párhuzamosan ezrével tudják próbálgatni a jelszavakat. A BCrypt ellen a GPU nagyon hatékony.

**Argon2 modern:**

**Memória-igényes** (Memory-hard): Nemcsak a processzort terheli, hanem szándékosan sok RAM-ot tölt meg szeméttel a számítás alatt.

**Az előny**: A GPU-kban ugyan sok számítási egység van, de viszonylag kevés memória jut egy szálra. Emiatt GPU-val Argon2-t törni nagyon drága és lassú. Ez a fő oka annak, hogy biztonságosabb.

