### PR TITLE
EX-260: Use lombok field name generator

### DIFF
--- a/backend/exence/src/main/java/com/exence/finance/modules/transaction/controller/impl/TransactionControllerImpl.java
+++ b/backend/exence/src/main/java/com/exence/finance/modules/transaction/controller/impl/TransactionControllerImpl.java
@@ -8,6 +8,7 @@ import com.exence.finance.modules.transaction.dto.TransactionType;
 import com.exence.finance.modules.transaction.dto.request.TransactionFilter;
 import com.exence.finance.modules.transaction.dto.response.RecurringTransactionsResponse;
 import com.exence.finance.modules.transaction.dto.response.TransactionTotalsResponse;
+import com.exence.finance.modules.transaction.entity.Transaction;
 import com.exence.finance.modules.transaction.service.TransactionService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -41,10 +42,9 @@ public class TransactionControllerImpl implements TransactionController {
         return ResponseFactory.ok(transactionDTO);
     }
 
-    // TODO: EX-241: Pageable annotation refactor
     @GetMapping()
     public ResponseEntity<PageResponse<TransactionDTO>> getTransactions(@Valid @ModelAttribute TransactionFilter filter,
-                                                                        @PageableDefault(sort = "date",
+                                                                        @PageableDefault(sort = Transaction.Fields.date,
                                                                                         direction = Sort.Direction.DESC,
                                                                                         size = 20) Pageable pageable) {
         Page<TransactionDTO> page = transactionService.getTransactions(filter, pageable);
@@ -53,7 +53,9 @@ public class TransactionControllerImpl implements TransactionController {
 
     @GetMapping("/income")
     public ResponseEntity<PageResponse<TransactionDTO>> getIncomes(@Valid @ModelAttribute TransactionFilter filter,
-                                                                   @PageableDefault(size = 20) Pageable pageable) {
+                                                                   @PageableDefault(sort = Transaction.Fields.date,
+                                                                           direction = Sort.Direction.DESC,
+                                                                           size = 20) Pageable pageable) {
         TransactionFilter incomeFilter = filter != null ? filter : new TransactionFilter();
         filter.setType(TransactionType.INCOME);
         Page<TransactionDTO> page = transactionService.getTransactions(filter, pageable);
@@ -62,7 +64,9 @@ public class TransactionControllerImpl implements TransactionController {
 
     @GetMapping("/expense")
     public ResponseEntity<PageResponse<TransactionDTO>> getExpenses(@Valid @ModelAttribute TransactionFilter filter,
-                                                                   @PageableDefault(size = 20) Pageable pageable) {
+                                                                    @PageableDefault(sort = Transaction.Fields.date,
+                                                                            direction = Sort.Direction.DESC,
+                                                                            size = 20) Pageable pageable) {
         TransactionFilter incomeFilter = filter != null ? filter : new TransactionFilter();
         filter.setType(TransactionType.EXPENSE);
         Page<TransactionDTO> page = transactionService.getTransactions(filter, pageable);
@@ -70,7 +74,9 @@ public class TransactionControllerImpl implements TransactionController {
     }
 
     @GetMapping("/recurring")
-    public ResponseEntity<RecurringTransactionsResponse> getRecurringTransactions(@PageableDefault(size = 20) Pageable pageable) {
+    public ResponseEntity<RecurringTransactionsResponse> getRecurringTransactions(@PageableDefault(sort = Transaction.Fields.date,
+            direction = Sort.Direction.DESC,
+            size = 20) Pageable pageable) {
         RecurringTransactionsResponse response = transactionService.getRecurringTransactions(pageable);
         return ResponseFactory.ok(response);
     }

--- a/backend/exence/src/main/java/com/exence/finance/modules/transaction/entity/Transaction.java
+++ b/backend/exence/src/main/java/com/exence/finance/modules/transaction/entity/Transaction.java
@@ -24,6 +24,7 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
+import lombok.experimental.FieldNameConstants;
 import lombok.experimental.SuperBuilder;
 import org.hibernate.annotations.Filter;
 
@@ -40,6 +41,7 @@ import static com.exence.finance.common.util.ValidationConstants.TRANSACTION_NOT
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
+@FieldNameConstants
 @EqualsAndHashCode(callSuper = false, exclude = { "user", "category" })
 @ToString(callSuper = true, exclude = { "user", "category" })
 @Table(name = "transaction")


### PR DESCRIPTION
sajnos a mappereknél nem tudjuk a statikusan generált attribútumokat haszálni mert mind a kettő annotation processor compile time nyomja, szval magic stringeknél maradunk ott, de minden más esetben ha szükség lesz valamelyik entity/dto attribútumára, akkor ezt kell használni.

a megoldásomban van egy példa a pageablere a transactionsnél, date attribútum


side note: töröltem a pageable refactor taskot, megterveztem, és arra jutottam hogy túl nagy overengineering lenne, amúgy is elég szép ez a @PageableDefault beépített annotáció, van rá minta, aztán minden entitynél csak más paramétert adunk meg neki, így marad