### PR TITLE
EX-281: Fix CI redundancy, improve job speed, suppress unnecessary rules for tests

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -12,39 +12,9 @@ env:
   GRADLE_OPTS: -Xmx1024m -XX:MaxMetaspaceSize=512m
 
 jobs:
-  code-quality:
-    name: Code Quality Checks
+  build-and-quality:
+    name: Quality, Test & Build
     runs-on: ubuntu-latest
-    
-    defaults:
-      run:
-        working-directory: backend/exence
-    
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Set up JDK 23
-        uses: actions/setup-java@v4
-        with:
-          distribution: 'zulu'
-          java-version: '23'
-          cache: gradle
-          cache-dependency-path: backend/exence/gradle/wrapper/gradle-wrapper.properties
-
-      - name: Make gradlew executable
-        run: chmod +x ./gradlew
-
-      - name: Check code formatting (Spotless)
-        run: ./gradlew spotlessCheck --no-daemon
-
-      - name: Run Checkstyle
-        run: ./gradlew checkstyleMain --no-daemon
-
-  build-test:
-    name: Build & Test
-    runs-on: ubuntu-latest
-    needs: code-quality
 
     services:
       postgres:
@@ -77,13 +47,10 @@ jobs:
       - name: Make gradlew executable
         run: chmod +x ./gradlew
 
-      - name: Run tests
-        run: ./gradlew test --no-daemon
+      - name: Run Quality Checks, Tests and Build
+        run: ./gradlew spotlessCheck checkstyleMain checkstyleTest test assemble --no-daemon
         env:
           SPRING_PROFILES_ACTIVE: test
           SPRING_DATASOURCE_URL: jdbc:postgresql://localhost:5432/exence_test
           SPRING_DATASOURCE_USERNAME: test
           SPRING_DATASOURCE_PASSWORD: test
-
-      - name: Build application
-        run: ./gradlew build -x test --no-daemon

--- a/backend/exence/config/checkstyle/checkstyle.xml
+++ b/backend/exence/config/checkstyle/checkstyle.xml
@@ -55,10 +55,6 @@
     <!-- Class design -->
     <module name="FinalClass"/>
     <module name="HideUtilityClassConstructor"/>
-    <module name="SuppressionXpathSingleFilter">
-      <property name="checks" value="HideUtilityClassConstructor"/>
-      <property name="query" value="//*[MODIFIERS//*[@text = 'UtilityClass']]"/>
-    </module>
     <module name="InterfaceIsType"/>
     <module name="OneTopLevelClass"/>
 
@@ -77,6 +73,21 @@
     </module>
     <module name="MethodLength">
       <property name="max" value="60"/>
+    </module>
+
+    <!-- Suppressions -->
+    <module name="SuppressionXpathSingleFilter">
+      <property name="checks" value="HideUtilityClassConstructor"/>
+      <property name="query" value="//*[MODIFIERS//*[@text = 'UtilityClass']]"/>
+    </module>
+    <module name="SuppressionXpathSingleFilter">
+      <property name="checks" value="MagicNumber"/>
+      <property name="files" value=".*[\\/]src[\\/]test[\\/].*"/>
+    </module>
+
+    <module name="SuppressionXpathSingleFilter">
+      <property name="checks" value="MethodName"/>
+      <property name="files" value=".*[\\/]src[\\/]test[\\/].*"/>
     </module>
 
 


### PR DESCRIPTION
problémák amiket megold ez a PR:
- túl szigorúak voltak a unit tesztekhez a szabályok 
-> **suppresselve lettek**
- 2-szer futottak a code quality checkek (egyszer az első jobban explicit futtatva, aztán a build parancs miatt implicit is) 
 -> **egy jobra lett átrakva minden, és mostmár 1 ./gradlew lánccal futnak EGY közös stepben, ami azt eredményezi, hogy nem kell többször elindítani a JVM-et, sok másodpercet és erőforrást megment a gradle így**

 