### PR TITLE
EX-280: Suppress null attributes from API responses

### DIFF
--- a/backend/exence/src/main/resources/application.yml
+++ b/backend/exence/src/main/resources/application.yml
@@ -49,6 +49,8 @@ spring:
           connectiontimeout: 5000
           timeout: 3000
           writetimeout: 5000
+  jackson:
+    default-property-inclusion: non_null
 
 # jwt configuration
 jwt:


### PR DESCRIPTION
így nem lesz csúnya az API response, tehát ha pl nem adunk meg a category-nak note-ot, akkor amikor lekérjük, nem kapunk `"note": null` -t
ha mégis kéne a null érték a frontendnek (pl törlés = nullt jelent vagy bármi), akkor lehet rakni a DTO-ra `@JsonInclude(JsonInclude.Include.ALWAYS` annotációt